### PR TITLE
geom_invert for negative rationals

### DIFF
--- a/lib/rational-number.js
+++ b/lib/rational-number.js
@@ -200,7 +200,7 @@ function arith_invert(n) {
 
 function geom_invert(n) {
     n = makeInstance(n);
-    return new Rational(n.denominator, n.numerator);
+    return new Rational(n.denominator, n.numerator, n.sign);
 }
 
 function abs(n) {


### PR DESCRIPTION
geom_invert does not consider the sign attribute of the Rational instance.
This breaks division by negative rationals, e.g. the division -1/-1 returns -1.
```
const q = new Rational(1,1,-1);
div(q,q).equal(q); // true
```