### PR TITLE
Creating a new Rational fails if denominator or numerator is larger than 32 bit integer

### DIFF
--- a/lib/fast-factorize.js
+++ b/lib/fast-factorize.js
@@ -1,6 +1,6 @@
 function fastFactorize(n) {
     const primeFactors = [];
-    const sqrt = ~~Math.sqrt(n);
+    const sqrt = n == Infinity ? 0 : Math.floor(Math.sqrt(n));
 
     let i = 2; // smallest prime
     while (i <= sqrt && n != 1) {

--- a/lib/rational-number.js
+++ b/lib/rational-number.js
@@ -86,8 +86,8 @@ class Rational {
         }
 
         // take care of double floating points
-        const nIsFloat = numerator != ~~numerator && numerator !== Infinity && !isNaN(numerator);
-        const dIsFloat = denominator != ~~denominator && denominator !== Infinity && !isNaN(denominator);
+        const nIsFloat = numerator !== Math.floor(numerator) && numerator !== Infinity && !isNaN(numerator);
+        const dIsFloat = denominator !== Math.floor(denominator) && denominator !== Infinity && !isNaN(denominator);
         if (nIsFloat || dIsFloat) {
             const [nn, nd] = nIsFloat ? floatToIntegerPair(numerator) : [numerator, 1];
             const [dn, dd] = dIsFloat ? floatToIntegerPair(denominator) : [denominator, 1];

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,10 @@ describe('Rational', () => {
             new Rational(3.5, 10.5).equal(new Rational(1, 3)).should.be.true;
         });
 
+        it('should handle large numerator & denumerator', () => {
+            new Rational(10000000000, 10000000000).valueOf().should.equal(1);
+        });
+
         describe('Infinities', () => {
             it('should correctly accept JavaScript primitive Infinity as numerator', () => {
                 new Rational(Infinity).valueOf().should.equal(Infinity);


### PR DESCRIPTION
For example when trying to

```javascript
add(r`1/100000`, r`1/100000`)
```
it throws an error:

> Uncaught TypeError: Cannot read property 'length' of undefined
>     at floatToIntegerPair (rational-arithmetic/lib/rational-number.js:28:47)
>     at new Rational (rational-arithmetic/lib/rational-number.js:93:41)
>     at add (rational-arithmetic/lib/rational-number.js:221:15)
>     at rational-arithmetic/src/main.js:72:42
>     at Array.reduce (<anonymous>)
>     at addMany (rational-arithmetic/src/main.js:72:21)

when add operation is trying to create `new Rational(200000, 10000000000)`

This happens because when checking if number is a floating point number using `number != ~~number`, it fails if number to check is larger than 32 bit integer.